### PR TITLE
CMW-81: Add multiassets to inputs and outputs in tx discovery

### DIFF
--- a/src/dbsync/api.rs
+++ b/src/dbsync/api.rs
@@ -38,8 +38,7 @@ pub fn get_utxo_tokens(
     Ok(multi_assets)
 }
 
-// stxo = spent transaction output (as opposed to utxo, which is unspent)
-pub fn get_stxo_tokens(
+pub fn get_txo_tokens(
     dbs: &DBSyncProvider,
     tx_id: i64,
     tx_index: i16,
@@ -2015,15 +2014,14 @@ mod tests {
         assert_eq!(func_value.txhash, real_value.txhash);
     }
 
-    // stxo = spent transaction output (as opposed to utxo, which is unspent)
     #[tokio::test]
     #[allow(non_snake_case)]
-    async fn get_stxo_tokens_CMW_81() {
+    async fn get_txo_tokens_CMW_81() {
         let dp = crate::DataProvider::new(crate::DBSyncProvider::new(crate::Config {
             db_path: dotenv::var("DBSYNC_DB_URL").unwrap(),
         }));
 
-        let utxo_tokens = super::get_stxo_tokens(
+        let utxo_tokens = super::get_txo_tokens(
             dp.provider(), 
             3312750, 
             0
@@ -2038,7 +2036,7 @@ mod tests {
 
         println!("utxo_tokens[0]: {:?}", utxo_tokens[0]);
 
-        let utxo_tokens = super::get_stxo_tokens(
+        let utxo_tokens = super::get_txo_tokens(
             dp.provider(), 
             3312750, 
             1
@@ -2126,20 +2124,50 @@ mod tests {
 
         let utxo_tokens = super::get_utxo_tokens(
             dp.provider(), 
-            3312750, 
+            3317731, 
             0
         ).unwrap();
 
-        // verify that the multiassets don't display (key distinguishing feature of get_utxo_tokens from get_stxo_tokens)
-        assert_eq!(utxo_tokens.len(), 0);
+        assert_eq!(utxo_tokens[0].id, 25777);
+        assert_eq!(utxo_tokens[0].fingerprint, "asset1jr6nl54y3rvpqfpmpau95q9lvu59fwq4f9xf9a");
+        assert_eq!(utxo_tokens[0].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[0].policy.clone()), "314de5f1c06ca6261a9159bfba61cfba8f4fb3ff37a2d68ec1b54c8a");
+        assert_eq!(hex::encode(utxo_tokens[0].name.clone()), "546573746e65744e4654202337");
+
+        assert_eq!(utxo_tokens[1].id, 391);
+        assert_eq!(utxo_tokens[1].fingerprint, "asset1m099azmatp3f3xehsu4sqvr45jzqafxmm0dra0");
+        assert_eq!(utxo_tokens[1].quantity, BigDecimal::from(150));
+        assert_eq!(hex::encode(utxo_tokens[1].policy.clone()), "3f1d9bd2f8c3d7d8144b789433261370eaf25cdc83fe8a745ef880c1");
+        assert_eq!(hex::encode(utxo_tokens[1].name.clone()), "744452415341");
+
+        assert_eq!(utxo_tokens[2].id, 2746);
+        assert_eq!(utxo_tokens[2].fingerprint, "asset10q8zsrnx5plw0k2l2e8slcjf4htuvu42jxrgl8");
+        assert_eq!(utxo_tokens[2].quantity, BigDecimal::from(50));
+        assert_eq!(hex::encode(utxo_tokens[2].policy.clone()), "dfd18a815a25339777dcc80bce9c438ad632272d95f334a111711ac9");
+        assert_eq!(hex::encode(utxo_tokens[2].name.clone()), "7441726b");
 
         let utxo_tokens = super::get_utxo_tokens(
             dp.provider(), 
-            3312750, 
-            0
+            3317731, 
+            1
         ).unwrap();
 
-        // verify that the multiassets don't display (key distinguishing feature of get_utxo_tokens from get_stxo_tokens)
-        assert_eq!(utxo_tokens.len(), 0);
+        assert_eq!(utxo_tokens[0].id, 367);
+        assert_eq!(utxo_tokens[0].fingerprint, "asset1wn7x62hf07wp36u6nmux467nrsngrcvurwqvm2");
+        assert_eq!(utxo_tokens[0].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[0].policy.clone()), "55e9a9737f5ee3f3a04a80b5bc9419c87724187318bd7ac376141e10");
+        assert_eq!(hex::encode(utxo_tokens[0].name.clone()), "74656e4e465435");
+
+        assert_eq!(utxo_tokens[1].id, 392);
+        assert_eq!(utxo_tokens[1].fingerprint, "asset1e83uya776dvqjauy270qnj03899hxxant6jp2g");
+        assert_eq!(utxo_tokens[1].quantity, BigDecimal::from(75));
+        assert_eq!(hex::encode(utxo_tokens[1].policy.clone()), "c693a41d2b4f241c992b88c7238131d92202206ffc92f5eae090d0ee");
+        assert_eq!(hex::encode(utxo_tokens[1].name.clone()), "7454657374");
+
+        assert_eq!(utxo_tokens[2].id, 2746);
+        assert_eq!(utxo_tokens[2].fingerprint, "asset10q8zsrnx5plw0k2l2e8slcjf4htuvu42jxrgl8");
+        assert_eq!(utxo_tokens[2].quantity, BigDecimal::from(50));
+        assert_eq!(hex::encode(utxo_tokens[2].policy.clone()), "dfd18a815a25339777dcc80bce9c438ad632272d95f334a111711ac9");
+        assert_eq!(hex::encode(utxo_tokens[2].name.clone()), "7441726b");
     }
 }

--- a/src/dbsync/api.rs
+++ b/src/dbsync/api.rs
@@ -2029,11 +2029,11 @@ mod tests {
             0
         ).unwrap();
 
-        // can't test policy and name due to non-UTF8 characters in DB explorer
-        assert_eq!(utxo_tokens.len(), 1);
         assert_eq!(utxo_tokens[0].id, 125105);
         assert_eq!(utxo_tokens[0].fingerprint, "asset1vyhv522fs7tg4kyky042empuaeg0e5v9aur0w0");
         assert_eq!(utxo_tokens[0].quantity, BigDecimal::from(3));
+        assert_eq!(hex::encode(utxo_tokens[0].policy.clone()), "4b9ae3978af62cf98dcc3b9aecc3dbbd2f59fa06b55e1f443e3c7c81");
+        assert_eq!(hex::encode(utxo_tokens[0].name.clone()), "ce036a77053b02d10fecc454368896325fd2ac7f5966bb9a35fe794b7bbf850f");
 
 
         println!("utxo_tokens[0]: {:?}", utxo_tokens[0]);
@@ -2044,44 +2044,77 @@ mod tests {
             1
         ).unwrap();
 
-        // can't test policy and name due to non-UTF8 characters in DB explorer
-        assert_eq!(utxo_tokens.len(), 12);
         assert_eq!(utxo_tokens[0].id, 86452);
         assert_eq!(utxo_tokens[0].fingerprint, "asset1gquup8evek9psft57ka29atuv9t4ekujfeulay");
         assert_eq!(utxo_tokens[0].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[0].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[0].name.clone()), "079389604744f143190973559b08cc12ce044f51c56527ddb05a8d648a265f76");
+
         assert_eq!(utxo_tokens[1].id, 86839);
         assert_eq!(utxo_tokens[1].fingerprint, "asset14hltlww3q8alhqznyz0t5rnz3wrpgg8762lsxk");
         assert_eq!(utxo_tokens[1].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[1].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[1].name.clone()), "466f56e732c05a5b6c0a4b72059ca0b34dfc8b2686fe870abc65ea8c28389265");
+
         assert_eq!(utxo_tokens[2].id, 86784);
         assert_eq!(utxo_tokens[2].fingerprint, "asset1xh75cc98vzh5s7hw37gzgxuaj67ark2p52lwgv");
         assert_eq!(utxo_tokens[2].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[2].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[2].name.clone()), "52b31a059b63ce58cc129aa14979458190b45c93c0213341799d0b97d8ad69be");
+
         assert_eq!(utxo_tokens[3].id, 90128);
         assert_eq!(utxo_tokens[3].fingerprint, "asset189z77fxt2h758mgth5rc6m2tavsj0s6kepwxf9");
         assert_eq!(utxo_tokens[3].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[3].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[3].name.clone()), "5be074649f3657223e4d1d06eb18dc6df603459efb94c6893f8613975dbf5b8c");
+
         assert_eq!(utxo_tokens[4].id, 86813);
         assert_eq!(utxo_tokens[4].fingerprint, "asset13nmc52yg556gpu4u53stk8fc5qfhvvyadrd78r");
         assert_eq!(utxo_tokens[4].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[4].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[4].name.clone()), "6a11a2299502c640830dce1a830f4a20b3f1451edd46606d7219e7d9765caa06");
+
         assert_eq!(utxo_tokens[5].id, 86365);
         assert_eq!(utxo_tokens[5].fingerprint, "asset10n9gjx0h40un2tl5wpx5dr4h0zg8yqkdc7u468");
         assert_eq!(utxo_tokens[5].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[5].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[5].name.clone()), "6c541e3e0ff73ca23a543d372e7455989c29a2df8b55496890e3f00418f64a97");
+
         assert_eq!(utxo_tokens[6].id, 86923);
         assert_eq!(utxo_tokens[6].fingerprint, "asset1lg82x7zq3c3fy7w29crkwmnfuv2hj03p2ygmc6");
         assert_eq!(utxo_tokens[6].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[6].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[6].name.clone()), "966a2d0a8a6b14e67455f9cb3e4ac59cfa6c75b570ead071b1cf1a1472a549c4");
+
         assert_eq!(utxo_tokens[7].id, 86963);
         assert_eq!(utxo_tokens[7].fingerprint, "asset16x02ett6wtfjkf4ayz2zfjgec2m6pyr6r6xrmr");
         assert_eq!(utxo_tokens[7].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[7].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[7].name.clone()), "a2b7d3bd6c650fe388b67841d321d39bdcfcb42a7be15163d033f28a742ca9d6");
+
         assert_eq!(utxo_tokens[8].id, 100979);
         assert_eq!(utxo_tokens[8].fingerprint, "asset14e7yfrgurya54e9k83axv3hw3s0kxluz289juu");
         assert_eq!(utxo_tokens[8].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[8].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[8].name.clone()), "d8ae43a1a2a0ab24709fb6fc497963dc30d8b1ee941fb774f1c8f05f98e6e556");
+
         assert_eq!(utxo_tokens[9].id, 88257);
         assert_eq!(utxo_tokens[9].fingerprint, "asset1g5ekxpjwnxu43qaejp3ml8hdfqa38ug7w4z6pw");
         assert_eq!(utxo_tokens[9].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[9].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[9].name.clone()), "e52c1140e73aaf9c96cfb6a5f8a40de63cf9c75f9f25ae8a9359df39e037566e");
+
         assert_eq!(utxo_tokens[10].id, 86920);
         assert_eq!(utxo_tokens[10].fingerprint, "asset13a25l8trzvf3g2pa4lfpmzdtas6wyrn07rjr9q");
         assert_eq!(utxo_tokens[10].quantity, BigDecimal::from(1));
+        assert_eq!(hex::encode(utxo_tokens[10].policy.clone()), "8819741bc9cb6299093bea6a6d306fb5faaf3aa4102ae43b8381837d");
+        assert_eq!(hex::encode(utxo_tokens[10].name.clone()), "f32ba079cfbc64e8119354e93f3ce804922b5499d4e8265e50bc4cf0f65fd490");
+
         assert_eq!(utxo_tokens[11].id, 6425);
         assert_eq!(utxo_tokens[11].fingerprint, "asset1qpcwhg7cvg7wr4m5xa3vd2s79lutkf044pmg4z");
         assert_eq!(utxo_tokens[11].quantity, BigDecimal::from(199217790));
+        assert_eq!(hex::encode(utxo_tokens[11].policy.clone()), "fdc6402cf6c5a22e389ebb3f813af09f3502377885c2046e98ce2c88");
+        assert_eq!(hex::encode(utxo_tokens[11].name.clone()), "69555344");
     }
 
     #[tokio::test]
@@ -2097,6 +2130,7 @@ mod tests {
             0
         ).unwrap();
 
+        // verify that the multiassets don't display (key distinguishing feature of get_utxo_tokens from get_stxo_tokens)
         assert_eq!(utxo_tokens.len(), 0);
 
         let utxo_tokens = super::get_utxo_tokens(
@@ -2105,6 +2139,7 @@ mod tests {
             0
         ).unwrap();
 
+        // verify that the multiassets don't display (key distinguishing feature of get_utxo_tokens from get_stxo_tokens)
         assert_eq!(utxo_tokens.len(), 0);
     }
 }

--- a/src/dbsync/api.rs
+++ b/src/dbsync/api.rs
@@ -15,7 +15,7 @@ use log::debug;
 use std::str::FromStr;
 /// get all tokens of an utxo
 
-pub fn get_utxo_tokens_for_utxo_view(
+pub fn get_utxo_tokens(
     dbs: &DBSyncProvider,
     tx_id: i64,
     tx_index: i16,
@@ -38,7 +38,8 @@ pub fn get_utxo_tokens_for_utxo_view(
     Ok(multi_assets)
 }
 
-pub fn get_utxo_tokens_for_txout(
+// stxo = spent transaction output (as opposed to utxo, which is unspent)
+pub fn get_stxo_tokens(
     dbs: &DBSyncProvider,
     tx_id: i64,
     tx_index: i16,
@@ -2014,14 +2015,15 @@ mod tests {
         assert_eq!(func_value.txhash, real_value.txhash);
     }
 
+    // stxo = spent transaction output (as opposed to utxo, which is unspent)
     #[tokio::test]
     #[allow(non_snake_case)]
-    async fn get_utxo_tokens_for_txout_CMW_81() {
+    async fn get_stxo_tokens_CMW_81() {
         let dp = crate::DataProvider::new(crate::DBSyncProvider::new(crate::Config {
             db_path: dotenv::var("DBSYNC_DB_URL").unwrap(),
         }));
 
-        let utxo_tokens = super::get_utxo_tokens_for_txout(
+        let utxo_tokens = super::get_stxo_tokens(
             dp.provider(), 
             3312750, 
             0
@@ -2036,7 +2038,7 @@ mod tests {
 
         println!("utxo_tokens[0]: {:?}", utxo_tokens[0]);
 
-        let utxo_tokens = super::get_utxo_tokens_for_txout(
+        let utxo_tokens = super::get_stxo_tokens(
             dp.provider(), 
             3312750, 
             1
@@ -2084,12 +2086,12 @@ mod tests {
 
     #[tokio::test]
     #[allow(non_snake_case)]
-    async fn get_utxo_tokens_for_utxo_view_CMW_81() {
+    async fn get_utxo_tokens_CMW_81() {
         let dp = crate::DataProvider::new(crate::DBSyncProvider::new(crate::Config {
             db_path: dotenv::var("DBSYNC_DB_URL").unwrap(),
         }));
 
-        let utxo_tokens = super::get_utxo_tokens_for_utxo_view(
+        let utxo_tokens = super::get_utxo_tokens(
             dp.provider(), 
             3312750, 
             0
@@ -2097,7 +2099,7 @@ mod tests {
 
         assert_eq!(utxo_tokens.len(), 0);
 
-        let utxo_tokens = super::get_utxo_tokens_for_utxo_view(
+        let utxo_tokens = super::get_utxo_tokens(
             dp.provider(), 
             3312750, 
             0

--- a/src/dbsync/api.rs
+++ b/src/dbsync/api.rs
@@ -23,10 +23,8 @@ pub fn get_utxo_tokens(
     let multi_assets = multi_asset::table
         .inner_join(ma_tx_out::table.on(multi_asset::id.eq(ma_tx_out::ident)))
         .inner_join(tx_out::table.on(tx_out::id.eq(ma_tx_out::tx_out_id)))
-        .inner_join(utxo_view::table.on(utxo_view::id.eq(tx_out::id)))
-        .filter(utxo_view::tx_id.eq(tx_id))
-        .filter(utxo_view::index.eq(tx_index))
-        //.select((multi_asset::id,multi_asset::policy,multi_asset::name,multi_asset::fingerprint))
+        .filter(tx_out::tx_id.eq(tx_id))
+        .filter(tx_out::index.eq(tx_index))
         .select((
             multi_asset::id,
             multi_asset::policy,
@@ -1991,5 +1989,27 @@ mod tests {
         assert_eq!(func_value.json, real_value.json);
         assert_eq!(func_value.mint_slot, real_value.mint_slot);
         assert_eq!(func_value.txhash, real_value.txhash);
+    }
+
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn get_utxo_tokens_CMW_81() {
+        let dp = crate::DataProvider::new(crate::DBSyncProvider::new(crate::Config {
+            db_path: dotenv::var("DBSYNC_DB_URL").unwrap(),
+        }));
+
+        let utxo_tokens = super::get_utxo_tokens(
+            dp.provider(), 
+            3312750, 
+            0
+        ).unwrap();
+        assert_eq!(utxo_tokens.len(), 1);
+
+        let utxo_tokens = super::get_utxo_tokens(
+            dp.provider(), 
+            3312750, 
+            1
+        ).unwrap();
+        assert_eq!(utxo_tokens.len(), 12);
     }
 }

--- a/src/dbsync/api.rs
+++ b/src/dbsync/api.rs
@@ -2030,7 +2030,7 @@ mod tests {
         // can't test policy and name due to non-UTF8 characters in DB explorer
         assert_eq!(utxo_tokens.len(), 1);
         assert_eq!(utxo_tokens[0].id, 125105);
-        assert_eq!(utxo_tokens[0].fingerprint, "asset1vyhv522fs7tg4kyky042empuaeg0e5v9aur0w0".to_string());
+        assert_eq!(utxo_tokens[0].fingerprint, "asset1vyhv522fs7tg4kyky042empuaeg0e5v9aur0w0");
         assert_eq!(utxo_tokens[0].quantity, BigDecimal::from(3));
 
 
@@ -2045,40 +2045,40 @@ mod tests {
         // can't test policy and name due to non-UTF8 characters in DB explorer
         assert_eq!(utxo_tokens.len(), 12);
         assert_eq!(utxo_tokens[0].id, 86452);
-        assert_eq!(utxo_tokens[0].fingerprint, "asset1gquup8evek9psft57ka29atuv9t4ekujfeulay".to_string());
+        assert_eq!(utxo_tokens[0].fingerprint, "asset1gquup8evek9psft57ka29atuv9t4ekujfeulay");
         assert_eq!(utxo_tokens[0].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[1].id, 86839);
-        assert_eq!(utxo_tokens[1].fingerprint, "asset14hltlww3q8alhqznyz0t5rnz3wrpgg8762lsxk".to_string());
+        assert_eq!(utxo_tokens[1].fingerprint, "asset14hltlww3q8alhqznyz0t5rnz3wrpgg8762lsxk");
         assert_eq!(utxo_tokens[1].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[2].id, 86784);
-        assert_eq!(utxo_tokens[2].fingerprint, "asset1xh75cc98vzh5s7hw37gzgxuaj67ark2p52lwgv".to_string());
+        assert_eq!(utxo_tokens[2].fingerprint, "asset1xh75cc98vzh5s7hw37gzgxuaj67ark2p52lwgv");
         assert_eq!(utxo_tokens[2].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[3].id, 90128);
-        assert_eq!(utxo_tokens[3].fingerprint, "asset189z77fxt2h758mgth5rc6m2tavsj0s6kepwxf9".to_string());
+        assert_eq!(utxo_tokens[3].fingerprint, "asset189z77fxt2h758mgth5rc6m2tavsj0s6kepwxf9");
         assert_eq!(utxo_tokens[3].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[4].id, 86813);
-        assert_eq!(utxo_tokens[4].fingerprint, "asset13nmc52yg556gpu4u53stk8fc5qfhvvyadrd78r".to_string());
+        assert_eq!(utxo_tokens[4].fingerprint, "asset13nmc52yg556gpu4u53stk8fc5qfhvvyadrd78r");
         assert_eq!(utxo_tokens[4].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[5].id, 86365);
-        assert_eq!(utxo_tokens[5].fingerprint, "asset10n9gjx0h40un2tl5wpx5dr4h0zg8yqkdc7u468".to_string());
+        assert_eq!(utxo_tokens[5].fingerprint, "asset10n9gjx0h40un2tl5wpx5dr4h0zg8yqkdc7u468");
         assert_eq!(utxo_tokens[5].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[6].id, 86923);
-        assert_eq!(utxo_tokens[6].fingerprint, "asset1lg82x7zq3c3fy7w29crkwmnfuv2hj03p2ygmc6".to_string());
+        assert_eq!(utxo_tokens[6].fingerprint, "asset1lg82x7zq3c3fy7w29crkwmnfuv2hj03p2ygmc6");
         assert_eq!(utxo_tokens[6].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[7].id, 86963);
-        assert_eq!(utxo_tokens[7].fingerprint, "asset16x02ett6wtfjkf4ayz2zfjgec2m6pyr6r6xrmr".to_string());
+        assert_eq!(utxo_tokens[7].fingerprint, "asset16x02ett6wtfjkf4ayz2zfjgec2m6pyr6r6xrmr");
         assert_eq!(utxo_tokens[7].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[8].id, 100979);
-        assert_eq!(utxo_tokens[8].fingerprint, "asset14e7yfrgurya54e9k83axv3hw3s0kxluz289juu".to_string());
+        assert_eq!(utxo_tokens[8].fingerprint, "asset14e7yfrgurya54e9k83axv3hw3s0kxluz289juu");
         assert_eq!(utxo_tokens[8].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[9].id, 88257);
-        assert_eq!(utxo_tokens[9].fingerprint, "asset1g5ekxpjwnxu43qaejp3ml8hdfqa38ug7w4z6pw".to_string());
+        assert_eq!(utxo_tokens[9].fingerprint, "asset1g5ekxpjwnxu43qaejp3ml8hdfqa38ug7w4z6pw");
         assert_eq!(utxo_tokens[9].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[10].id, 86920);
-        assert_eq!(utxo_tokens[10].fingerprint, "asset13a25l8trzvf3g2pa4lfpmzdtas6wyrn07rjr9q".to_string());
+        assert_eq!(utxo_tokens[10].fingerprint, "asset13a25l8trzvf3g2pa4lfpmzdtas6wyrn07rjr9q");
         assert_eq!(utxo_tokens[10].quantity, BigDecimal::from(1));
         assert_eq!(utxo_tokens[11].id, 6425);
-        assert_eq!(utxo_tokens[11].fingerprint, "asset1qpcwhg7cvg7wr4m5xa3vd2s79lutkf044pmg4z".to_string());
+        assert_eq!(utxo_tokens[11].fingerprint, "asset1qpcwhg7cvg7wr4m5xa3vd2s79lutkf044pmg4z");
         assert_eq!(utxo_tokens[11].quantity, BigDecimal::from(199217790));
     }
 

--- a/src/dbsync/mod.rs
+++ b/src/dbsync/mod.rs
@@ -62,7 +62,7 @@ impl super::provider::CardanoDataProvider for DBSyncProvider {
         Ok(api::get_address_utxos(self, addr)?)
     }
 
-    async fn asset_utxos_on_addr( // unused
+    async fn asset_utxos_on_addr(
         &self,
         addr: &str,
     ) -> Result<dcslc::TransactionUnspentOutputs, DataProviderError> {
@@ -107,13 +107,13 @@ impl super::provider::CardanoDataProvider for DBSyncProvider {
         Ok(utxo)
     }
 
-    async fn utxo_tokens( // unused trait method
+    async fn utxo_tokens(
         &self,
         utxo_id: i64,
         index: i16,
     ) -> Result<Vec<CardanoNativeAssetView>, DataProviderError>
     {
-        Ok(api::get_utxo_tokens_for_utxo_view(self, utxo_id, index)?)
+        Ok(api::get_utxo_tokens(self, utxo_id, index)?)
     }
 
     async fn find_datums_for_tx(

--- a/src/dbsync/mod.rs
+++ b/src/dbsync/mod.rs
@@ -62,7 +62,7 @@ impl super::provider::CardanoDataProvider for DBSyncProvider {
         Ok(api::get_address_utxos(self, addr)?)
     }
 
-    async fn asset_utxos_on_addr(
+    async fn asset_utxos_on_addr( // unused
         &self,
         addr: &str,
     ) -> Result<dcslc::TransactionUnspentOutputs, DataProviderError> {
@@ -107,13 +107,13 @@ impl super::provider::CardanoDataProvider for DBSyncProvider {
         Ok(utxo)
     }
 
-    async fn utxo_tokens(
+    async fn utxo_tokens( // unused trait method
         &self,
         utxo_id: i64,
         index: i16,
     ) -> Result<Vec<CardanoNativeAssetView>, DataProviderError>
     {
-        Ok(api::get_utxo_tokens(self, utxo_id, index)?)
+        Ok(api::get_utxo_tokens_for_utxo_view(self, utxo_id, index)?)
     }
 
     async fn find_datums_for_tx(

--- a/src/dbsync/models.rs
+++ b/src/dbsync/models.rs
@@ -195,7 +195,7 @@ impl UtxoView {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
 
-        let tokens = api::get_utxo_tokens_for_utxo_view(&dbs, self.tx_id, self.index)?;
+        let tokens = api::get_utxo_tokens(&dbs, self.tx_id, self.index)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(
@@ -802,7 +802,7 @@ impl TxOut {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
         log::debug!("try to create tokens, Ada amount set Value from : {amount:?}");
-        let tokens = api::get_utxo_tokens_for_txout(&dbs, self.tx_id, self.index)?;
+        let tokens = api::get_stxo_tokens(&dbs, self.tx_id, self.index)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(

--- a/src/dbsync/models.rs
+++ b/src/dbsync/models.rs
@@ -12,6 +12,7 @@ use chrono::{NaiveDate, NaiveDateTime};
 use diesel::prelude::*;
 use diesel::sql_types::{Array, BigInt, Float8, Int4, Jsonb, Numeric};
 use diesel_derive_enum::DbEnum;
+use super::api;
 
 #[derive(Debug, Clone, DbEnum, QueryId)]
 #[ExistingTypePath = "crate::dbsync::schema::sql_types::Syncstatetype"]
@@ -102,7 +103,7 @@ impl UnspentUtxo {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
 
-        let tokens = super::api::get_utxo_tokens_dep(&dbs, self.id)?;
+        let tokens = api::get_utxo_tokens_dep(&dbs, self.id)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(
@@ -194,7 +195,7 @@ impl UtxoView {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
 
-        let tokens = super::api::get_utxo_tokens_for_utxo_view(&dbs, self.tx_id, self.index)?;
+        let tokens = api::get_utxo_tokens_for_utxo_view(&dbs, self.tx_id, self.index)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(
@@ -801,7 +802,7 @@ impl TxOut {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
         log::debug!("try to create tokens, Ada amount set Value from : {amount:?}");
-        let tokens = super::api::get_utxo_tokens_for_txout(&dbs, self.tx_id, self.index)?;
+        let tokens = api::get_utxo_tokens_for_txout(&dbs, self.tx_id, self.index)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(

--- a/src/dbsync/models.rs
+++ b/src/dbsync/models.rs
@@ -194,7 +194,7 @@ impl UtxoView {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
 
-        let tokens = super::api::get_utxo_tokens(&dbs, self.tx_id, self.index)?;
+        let tokens = super::api::get_utxo_tokens_for_utxo_view(&dbs, self.tx_id, self.index)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(
@@ -801,7 +801,7 @@ impl TxOut {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
         log::debug!("try to create tokens, Ada amount set Value from : {amount:?}");
-        let tokens = super::api::get_utxo_tokens(&dbs, self.tx_id, self.index)?;
+        let tokens = super::api::get_utxo_tokens_for_txout(&dbs, self.tx_id, self.index)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(

--- a/src/dbsync/models.rs
+++ b/src/dbsync/models.rs
@@ -802,7 +802,7 @@ impl TxOut {
             &cardano_serialization_lib::utils::to_bignum(coin),
         );
         log::debug!("try to create tokens, Ada amount set Value from : {amount:?}");
-        let tokens = api::get_stxo_tokens(&dbs, self.tx_id, self.index)?;
+        let tokens = api::get_txo_tokens(&dbs, self.tx_id, self.index)?;
         let mut ma = cardano_serialization_lib::MultiAsset::new();
         for tok in tokens {
             match ma.get(&cardano_serialization_lib::PolicyID::from_bytes(


### PR DESCRIPTION
Solves: https://worldmobile.atlassian.net/browse/CMW-81 

Description:
* Split `get_utxo_tokens` functions into `get_txo_tokens` (for transaction discovery, i.e. the endpoint that had problems according to ticket) and `get_utxo_tokens` (for all the other endpoints that were previously using `get_utxo_tokens`)
* Added unit tests for `get_txo_tokens` and `get_utxo_tokens`
* E2E test for `get_txo_tokens` via `/api/info/history/discover/{hash}` endpoint. The difference from previous version is that multiassets are now being displayed. 
* E2E test for `get_utxo_tokens` via the following endpoints:
  * `/api/info/utxos/{address}`
    *  The response is just a block of hex characters before and after. Thus no difference was noticed. 
  * `/api/info/address/stake/assets/`
    * `Invalid query string` in response, both before and after. Thus no difference was noticed. 
  * `/history/discover/{hash}`
    * this endpoint uses both `get_txo_tokens` and `get_utxo_tokens`. Multiassets are now displaying, but not before. 
* the unit test for `get_txo_tokens` is based on transaction hash `3a25ca26e496b6cd2233ad7471eb80e3f5ce957dfe84e38fa818b36d68cbac00`, which comes from a throwaway wallet specifically made for this task and nothing else, to guarantee that the UTxO:s remain unspent in the future (so that the unit test that succeeds today doesn't fail in the future). 