### PR TITLE
EN-486 add cache layer for heavy GRPC calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tonic = { version = "0.9.2", features = [
 ] }
 prost = "0.11.9"
 dotenv = "0.15.0"
+cached = "0.46.0"
 ######
 [build-dependencies]
 #  grpc

--- a/example_config.toml
+++ b/example_config.toml
@@ -3,6 +3,7 @@ None = {}
 
 [connectivity]
 dbsync_url = "postgres://user:password@localhost:5432/testnet"
+grpc_cache_size  = 50
 submit_endpoint_1 = "http://localhost:8090/api/submit/tx"
 submit_endpoint_2 = ""
 submit_endpoint_3 = ""

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -201,6 +201,7 @@ impl ConfigRoot {
             appconfigs::Config::None => {}
         }
         std::env::set_var("DBSYNC_URL", &self.connectivity.dbsync_url);
+        std::env::set_var("GRPC_CACHE_SIZE", &self.connectivity.grpc_cache_size.to_string());
         std::env::set_var("TX_SUBMIT_ENDPOINT1", &self.connectivity.submit_endpoint_1);
         std::env::set_var("TX_SUBMIT_ENDPOINT2", &self.connectivity.submit_endpoint_2);
         std::env::set_var("TX_SUBMIT_ENDPOINT3", &self.connectivity.submit_endpoint_3);
@@ -217,6 +218,7 @@ mod connectivity {
         pub submit_endpoint_1: String,
         pub submit_endpoint_2: String,
         pub submit_endpoint_3: String,
+        pub grpc_cache_size: usize,
         pub protocol_parameter_path: String,
         pub cert_private_key: Option<String>,
         pub cert_pub_key: String,

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -127,7 +127,6 @@ impl ChainFollowerRequestService for AyaCardanoRPCServer {
                 }
             }
         };
-        println!("Output: {output:?}");
         cache.cache_set(cache_key, encode_prost_message(&output));
         Ok(Response::new(output))
     }

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -31,8 +31,9 @@ pub struct AyaCardanoRPCServer {
 }
 impl Default for AyaCardanoRPCServer {
     fn default() -> Self {
+        let cache_size = std::env::var("GRPC_CACHE_SIZE").unwrap().parse::<usize>().unwrap();
         AyaCardanoRPCServer {
-            sized_cache: Mutex::new(SizedCache::with_size(50)),
+            sized_cache: Mutex::new(SizedCache::with_size(cache_size)),
         }
     }
 }


### PR DESCRIPTION
Add a caché layer to cache requests for some slow GRPC calls.

The cached values auto-expire after 1 min form epoch requests, and after 5 min for register/unregister requests.

The caching is performed through the crate cached (cached::TimedCache), using two different caches to get the 1/5min granularity. 

